### PR TITLE
Fixing problem with already existing tags

### DIFF
--- a/update_mirror.sh
+++ b/update_mirror.sh
@@ -37,11 +37,11 @@ if git config --get svn-remote.svn.url &> /dev/null;then
   git svn fetch
   git svn rebase
   git for-each-ref --format="%(objectname:short) %(refname)" refs/remotes/tags |  while read ref; do
-    objectname=$(echo $ref | cut -d " " -f 1)
-    tagname=$(echo $ref | cut -d " " -f 2 | cut -d / -f 4)
-    tag_already_exists=$(git show-ref --tags | egrep -q refs/tags/$tagname$)
-    if [ ! tag_already_exists ]; then
-      GIT_COMMITTER_DATE="$(git show --format=%aD  | head -1)" git tag -a $tagname -m "import '$tagname' tag from svn" $objectname
+    objectname=$(echo ${ref} | cut -d " " -f 1)
+    tagname=$(echo ${ref} | cut -d " " -f 2 | cut -d / -f 4)
+    if ! git show-ref --tags | grep -E -q "refs/tags/${tagname}$"; then
+      echo "Tag does not exist... creating it"
+      GIT_COMMITTER_DATE="$(git show --format=%aD  | head -1)" git tag -a ${tagname} -m "import '${tagname}' tag from svn" ${objectname}
     fi
   done
 


### PR DESCRIPTION
I had a problem with my sync, since there were errors with already existing tags.
I fixed the problem according to some hints from
  http://stackoverflow.com/questions/17790123/shell-script-trying-to-validate-if-a-git-tag-exists-in-a-git-repository-in-an

So now the tag is only done if it does not already exist.
However, egrep must be installed for this to work (can this be added as dependency somewhere)?
