### PR TITLE
Added support for version 4 of the Gitlab API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ gitlab-mirrors creates read only copies of remote repositories in gitlab.  It
 provides a CLI management interface for managing the mirrored repositories (e.g.
 add, delete, update) so that an admin may regularly update all mirrors using
 `crontab`.  It operates by interacting with the [GitLab API][gitlab-api] using
-[python-gitlab3][python-gitlab3].
+[python-gitlab][python-gitlab].
 
 ## Features
 
@@ -87,4 +87,4 @@ Created by Sam Gleske under [MIT License](LICENSE).
 [gm-puppet]: https://github.com/logicminds/gitlab_mirrors
 [issues]: https://github.com/samrocketman/gitlab-mirrors/issues
 [mirror-missing]: http://feedback.gitlab.com/forums/176466-general/suggestions/4286666-mirror-git-svn-into-repo-
-[python-gitlab3]: https://github.com/alexvh/python-gitlab3
+[python-gitlab]: https://github.com/python-gitlab/python-gitlab

--- a/add_mirror.sh
+++ b/add_mirror.sh
@@ -18,8 +18,11 @@ if [ ! -f "${git_mirrors_dir}/config.sh" ];then
   exit 1
 fi
 
+#check if api version is set
+[ -z $gitlab_api_version ] && gitlab_api_version=3
+
 #export env vars for python script
-export gitlab_user_token_secret gitlab_url gitlab_namespace gitlab_user ssl_verify
+export gitlab_user_token_secret gitlab_url gitlab_namespace gitlab_user ssl_verify gitlab_api_version
 
 PROGNAME="${0##*/}"
 PROGVERSION="${VERSION}"

--- a/add_mirror.sh
+++ b/add_mirror.sh
@@ -19,7 +19,7 @@ if [ ! -f "${git_mirrors_dir}/config.sh" ];then
 fi
 
 #check if api version is set
-[ -z $gitlab_api_version ] && gitlab_api_version=3
+[ -z $gitlab_api_version ] && gitlab_api_version=4
 
 #export env vars for python script
 export gitlab_user_token_secret gitlab_url gitlab_namespace gitlab_user ssl_verify gitlab_api_version

--- a/config.sh.SAMPLE
+++ b/config.sh.SAMPLE
@@ -43,7 +43,7 @@ gitlab_user="gitmirror"
 #Generate a token for your $gitlab_user and set it here.
 gitlab_user_token_secret="$(head -n1 "${user_home}/private_token" 2> /dev/null || echo "")"
 #Sets the Gitlab API version, either 3 or 4
-gitlab_api_version=3
+gitlab_api_version=4
 #Verify signed SSL certificates?
 ssl_verify=true
 #Push to GitLab over http?  Otherwise will push projects via SSH.

--- a/config.sh.SAMPLE
+++ b/config.sh.SAMPLE
@@ -42,6 +42,8 @@ gitlab_url="https://gitlab.example.com"
 gitlab_user="gitmirror"
 #Generate a token for your $gitlab_user and set it here.
 gitlab_user_token_secret="$(head -n1 "${user_home}/private_token" 2> /dev/null || echo "")"
+#Sets the Gitlab API version, either 3 or 4
+gitlab_api_version=3
 #Verify signed SSL certificates?
 ssl_verify=true
 #Push to GitLab over http?  Otherwise will push projects via SSH.

--- a/delete_mirror.sh
+++ b/delete_mirror.sh
@@ -17,7 +17,7 @@ if [ ! -f "${git_mirrors_dir}/config.sh" ];then
 fi
 
 #check if api version is set
-[ -z $gitlab_api_version ] && gitlab_api_version=3
+[ -z $gitlab_api_version ] && gitlab_api_version=4
 
 #export env vars for python script
 export gitlab_user_token_secret gitlab_url gitlab_namespace gitlab_user ssl_verify gitlab_api_version

--- a/delete_mirror.sh
+++ b/delete_mirror.sh
@@ -16,8 +16,11 @@ if [ ! -f "${git_mirrors_dir}/config.sh" ];then
   exit 1
 fi
 
+#check if api version is set
+[ -z $gitlab_api_version ] && gitlab_api_version=3
+
 #export env vars for python script
-export gitlab_user_token_secret gitlab_url gitlab_namespace gitlab_user ssl_verify
+export gitlab_user_token_secret gitlab_url gitlab_namespace gitlab_user ssl_verify gitlab_api_version
 
 cd "${git_mirrors_dir}"
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -2,8 +2,8 @@
 
 ### Required software
 
-* [Tested with GitLab 6.x/7.x/8.x][gitlab]
-* [pyapi-gitlab3 @ v0.5.4][python-gitlab3]
+* [Tested with GitLab 8.x/9.x/10/x][gitlab]
+* [python-gitlab @ v1.1.0][python-gitlab]
 * [GNU coreutils][coreutils]
 * [git 1.8.0][git] or later
 
@@ -24,14 +24,10 @@ aditional options.
 
 ### Required software install snippets
 
-#### python-gitlab3
+#### python-gitlab
 
-    yum install python-setuptools
-    git clone https://github.com/alexvh/python-gitlab3.git
-    cd python-gitlab3
-    git checkout v0.5.4
-    python setup.py install
-
+    yum install python-pip
+    pip install python-gitlab
 
 #### Installing git
 
@@ -93,4 +89,4 @@ Next up is [Installation and Setup](installation.md).
 [gitlab]: https://about.gitlab.com/
 [git-src]: http://code.google.com/p/git-core/
 [git-svn]: https://www.kernel.org/pub/software/scm/git/docs/git-svn.html
-[python-gitlab3]: https://github.com/alexvh/python-gitlab3
+[python-gitlab]: https://github.com/python-gitlab/python-gitlab

--- a/docs/upgrade/upgrade_0.5.x-0.6.x.md
+++ b/docs/upgrade/upgrade_0.5.x-0.6.x.md
@@ -1,0 +1,36 @@
+# Upgrade Notes
+
+This documentation outlines steps for you to upgrade from gitlab-mirrors `0.5.x`
+to gitlab-mirrors `0.6.x`.  It is assumed you'll be working on a test instance
+of gitlab in a production environment.  If you only have a single gitlab
+instance then follow these steps with care and at your own risk.
+
+gitlab-mirrors has been certified to use a new prerequisite library called
+[python-gitlab](https://github.com/python-gitlab/python-gitlab).  Therefore 
+you must install `python-gitlab` before upgrading `gitlab-mirrors` to the latest 
+edition.
+
+# 1. Disable any cron jobs
+
+If you have cron jobs set up then you'll need to disable them to avoid them
+launching gitlab-mirrors during your upgrade.
+
+# 2. Update python-gitlab3 python-gitlab
+
+I'll ouline the steps here real quick.
+
+    yum install python-pip
+    pip uninstall gitlab3
+    pip install python-gitlab
+
+# 3. Update your gitlab-mirrors
+
+    su - gitmirror
+    cd gitlab-mirrors
+    git checkout master
+    git fetch
+    git pull origin master
+    git checkout v0.6.x
+
+Test on a dummy project to ensure your new setup works.  Once you have verified
+everything works then you can re-enable the cron jobs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-gitlab>=1.0.2,<2


### PR DESCRIPTION
Hi,

As already discussed, I managed to get this project to run with gitlab API version 4. A new parameter has been added to the config, gitlab_api_version, which defaults to version 3 for backward compatibility (even when it is not set).

I tested it with Gitlab 8, 9 & 10 all seem to be working fine.

The only thing that is still left to do is update the documentation. I could add it to this PR as well, but I saw that it was part of the release process and thus left it out.

The main difference here is that the python requirements are different. The basic requirement is to install python-gitlab (and its dependencies).