### PR TITLE
Switching to gitlab.v4

### DIFF
--- a/lib/manage_gitlab_project.py
+++ b/lib/manage_gitlab_project.py
@@ -121,7 +121,7 @@ def needs_transfer(user, groupname, project):
     namespace = groupname
   else:
     namespace = user
-  if type(project.namespace) == gitlab.v3.objects.Group:
+  if type(project.namespace) == gitlab.v4.objects.Group:
     return project.namespace.name != namespace
   else:
     return project.namespace['name'] != namespace


### PR DESCRIPTION
In order to work with current version of Gitlab (11.x) and python-gitlab (1.5.1) switched from gitlab.v3 to gitlab.v4.