### PR TITLE
force behaviour when searching for groups

### DIFF
--- a/lib/manage_gitlab_project.py
+++ b/lib/manage_gitlab_project.py
@@ -50,7 +50,7 @@ else:
   git=gitlab.Gitlab(gitlab_url,token_secret,ssl_verify=True,api_version=gitlab_api_version)
 
 def find_group(**kwargs):
-  groups = git.groups.list()
+  groups = git.groups.list(all_available=False)
   return _find_matches(groups, kwargs, False)
 
 def find_project(**kwargs):


### PR DESCRIPTION
* behaviour is different when mirror user is admin
  https://docs.gitlab.com/ce/api/groups.html
* Group cannot be found in some circumstances when "all_available = true" which is the default when a user with admin rights uses the script