### PR TITLE
meta: add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+### 
+# After building (eg. `docker build -t gitlab-mirrors .`) ...
+# you are expected to formulate a `docker run` command like the following:
+#
+# docker run -ti \
+#    --volume /path/to/config.sh:/home/gitmirror/gitlab-mirrors/config.sh:ro \
+#    --volume /path/to/ssh-keys:/home/gitmirror/.ssh \
+#    --volume /path/to/repositories:/home/gitmirror/repositories \
+#    gitlab-mirrors \
+#    <gitlab-mirrors cmd> <cmd options> # eg. add_mirror.sh --help 
+###
+FROM debian:10
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -yqq \
+            python-pip \
+            git
+
+RUN pip install python-gitlab
+
+RUN adduser --shell /bin/sh --disabled-password --gecos "" gitmirror
+
+RUN mkdir /home/gitmirror/gitlab-mirrors
+
+COPY . /home/gitmirror/gitlab-mirrors
+
+RUN chown -R gitmirror:gitmirror /home/gitmirror
+
+USER gitmirror
+
+WORKDIR /home/gitmirror/gitlab-mirrors
+
+RUN mkdir /home/gitmirror/repositories && \
+    chmod 755 /home/gitmirror/gitlab-mirrors/*.sh
+
+ENV PATH=$PATH:/home/gitmirror/gitlab-mirrors
+
+ENTRYPOINT [ "/bin/bash", "/home/gitmirror/gitlab-mirrors/scripts/docker/entrypoint.sh" ]

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu
+
+SSH_DIR=/home/gitmirror/.ssh
+
+if [ ! -f "$SSH_DIR/id_ed25519" ]; then
+	echo -e " * No SSH key found in $SSH_DIR.\n\
+ * You can generate a key like this:
+	 ssh-keygen -t ed25519 -f /path/to/ssh/key/dir/id_ed25519 -qN \"\"
+ * Then make sure to run this image with --volume /path/to/ssh/key/dir:$SSH_DIR"
+fi
+
+exec "$@"


### PR DESCRIPTION
This PR adds a Dockerfile and accompanying entrypoint.sh script.

This is made to be useful for both CI and for end users wanting to run gitlab-mirrors within a Docker image.