### PR TITLE
Add section for apt in prequisites

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -26,8 +26,15 @@ aditional options.
 
 #### python-gitlab
 
-    yum install python-pip
-    pip install python-gitlab
+##### dnf/yum
+```bash
+yum install python-pip
+pip install python-gitlab
+```
+##### apt
+```bash
+apt install -y python3-gitlab
+```
 
 #### Installing git
 


### PR DESCRIPTION
python3-gitlab is packaged in debian and can be installed through apt directly without the use of pip

(also debian discourages the use of pip outside of virtual envs since debian 12)